### PR TITLE
ci: disable wait for sonar gate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,6 @@ pipeline {
             '''
           }
         }
-        waitForQualityGate abortPipeline: true
       }
     }
 


### PR DESCRIPTION
instead depend upon gh status checks

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>